### PR TITLE
fix battery output formatting

### DIFF
--- a/battery.c
+++ b/battery.c
@@ -43,7 +43,13 @@ int put_infos(char *path, char *format)
         fprintf(stderr, "The battery informations are missing.\n");
         return EXIT_FAILURE;
     } else {
-        printf(format, status, capacity);
+        if(strstr(format, "%s")==NULL) {
+            printf(format, capacity);
+        }else if(strstr(format, "%i")==NULL) {
+            printf(format, status);
+        }else{
+            printf(format, status, capacity);
+        }
         printf("\n");
         fflush(stdout);
     }


### PR DESCRIPTION
The battery formatting now also works when only %i is present in the format string, previously it would return random integer value.
