### PR TITLE
Fix makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ debug: CFLAGS += -O0 -g -DDEBUG
 debug: $(BIN)
 
 $(BIN): Makefile
-	$(CC) $(CFLAGS) $(LDFLAGS) $(LIBS) -o $@ $@.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $@.c $(LIBS)
 
 install:
 	mkdir -p "$(DESTDIR)$(BINPREFIX)"


### PR DESCRIPTION
The PKGBUILD in AUR was failing to build for me after adding the `volume.c` because of undefined references to asound. I have `--as-needed` in my LDFLAGS (set in `/etc/makepkg.conf`, it's the default on Arch), and that dropped all the references because the libs were listed before the .c files in the linking command. Moving `$(LIBS)` to the end of that line fixes the reference errors (as now gcc can see there are actually some symbols needed from asound). I tested building from my branch with the PKGBUILD, and it went just fine.