### PR TITLE
Reorganize libs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC      ?= gcc
-LIBS     = -lm -lasound
+LIBS     = -lasound
 CFLAGS  += -std=c99 -pedantic -Wall -Wextra -I$(PREFIX)/include
 CFLAGS  += -D_POSIX_C_SOURCE=200112L
 LDFLAGS += -L$(PREFIX)/lib

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 CC      ?= gcc
-LIBS     = -lasound
 CFLAGS  += -std=c99 -pedantic -Wall -Wextra -I$(PREFIX)/include
 CFLAGS  += -D_POSIX_C_SOURCE=200112L
 LDFLAGS += -L$(PREFIX)/lib

--- a/Sourcedeps
+++ b/Sourcedeps
@@ -4,4 +4,5 @@ essid: essid.c
 exist: exist.c
 narg: narg.c
 uq: uq.c
+volume: LIBS = -lasound
 volume: volume.c


### PR DESCRIPTION
Removes unneeded -lm flag from LIBS and moves said variable to Sourcedeps.